### PR TITLE
Change link to github repos

### DIFF
--- a/site/_includes/themes/apache/_navigation.html
+++ b/site/_includes/themes/apache/_navigation.html
@@ -27,7 +27,7 @@
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Development<b class="caret"></b></a>
               <ul class="dropdown-menu dropdown-left">
                 <li><a class="external" href="https://cwiki.apache.org/confluence/display/DAFFODIL/">Wiki</a></li>
-                <li><a class="external" href="https://github.com/search?q=repo%3Aapache%2Fdaffodil+repo%3Aapache%2Fdaffodil-site&type=Repositories">GitHub</a></li>
+                <li><a class="external" href="https://github.com/apache/?q=daffodil">GitHub</a></li>
                 <li><a class="external" href="https://issues.apache.org/jira/projects/DAFFODIL/">JIRA</a></li>
               </ul>
             </li>


### PR DESCRIPTION
This link searches for all daffodil repos in the Apache organization, so
as we add new repos the will automatically be listed. Previously the
link had to be manually updated.