### PR TITLE
Update CLI documentation for Daffodil 3.1.0

### DIFF
--- a/site/cli.md
+++ b/site/cli.md
@@ -21,28 +21,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 {% endcomment %}
 -->
+<!-- markdownlint-disable line-length -->
+<!-- markdownlint-disable no-duplicate-heading -->
 
-The binary Daffodil [releases](/releases) contain a ``/bin`` directory that contains two scripts: ``daffodil.bat`` for Windows and ``daffodil`` for Linux. These files must be executed on the command line. The general usage is:
+The binary Daffodil [releases](/releases) contain a ``/bin`` directory with two scripts: ``daffodil.bat`` for Windows and ``daffodil`` for Linux. These files must be executed on the command line. The general usage is:
 
     daffodil [GLOBAL_OPTIONS] <subcommand> [SUBCOMMAND_OPTIONS]
 
-The available subcommands are: [parse](#parse-subcommand), [unparse](#unparse-subcommand), [save-parser](#save-parser-subcommand), [test](#test-subcommand), and [performance](#performance-subcommand).
+The available subcommands are:
+
+- [parse](#parse-subcommand)
+- [unparse](#unparse-subcommand)
+- [save-parser](#save-parser-subcommand)
+- [test](#test-subcommand)
+- [performance](#performance-subcommand)
+- [generate](#generate-subcommand)
 
 ### Environment Variables
 
-Setting environment variables may be necessary to allow for importing/includes to work and when running TDML files.
+Setting environment variables may be necessary to allow imports, includes, and running TDML files to work.
 
 ``DAFFODIL_CLASSPATH``
 
-   : The Daffodil CLI will look on the classpath for includes and imports, jars containing schemas, and some TDML files. To define additional directories specific to Daffodil to look for files, set the ``DAFFODIL_CLASSPATH`` environment variable, for example:
+   : Daffodil will search its classpath for includes and imports, jars containing schemas, and some TDML files. To tell Daffodil to look for files in additional directories, set the ``DAFFODIL_CLASSPATH`` environment variable, for example:
 
-         $ export DAFFODIL_CLASSPATH="/path/to/imports/:/path/to/includes/"
+         export DAFFODIL_CLASSPATH="/path/to/imports/:/path/to/includes/"
 
-     In addition to defining directories to search for imports and includes, you can add a CatalogManager.properties file to the ``DAFFODIL_CLASSPATH`` to direct Daffodil to a relative path location of a user XML Catalog.
+     In addition to defining directories to search for imports and includes, you can add a CatalogManager.properties file to ``DAFFODIL_CLASSPATH`` to direct Daffodil to a relative path location of a user XML Catalog.
 
 ``DAFFODIL_JAVA_OPTS``
 
    : If you need to specify java options specific to Daffodil, you can set the ``DAFFODIL_JAVA_OPTS`` environment variable. If not specified, the ``JAVA_OPTS`` environment variable will be used. If that is not specified, reasonable defaults for Daffodil will be used.
+
+``CC``
+
+   : If you need to specify which C compiler should be called when running TDML files with the ``test`` subcommand using Daffodil's runtime2 backend, you can set the ``CC`` environment variable. If that environment variable is not specified, then Daffodil will call the first C compiler driver command it finds within the ``PATH`` environment variable from the following list: "zig cc", "cc", "clang", "gcc" (in that order). The reason for "zig cc" coming first is because [zig cc](https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html) uses a sophisticated caching system to avoid recompiling the same C source files, which can speed up TDML tests.
 
 ### Global Options
 
@@ -50,7 +63,7 @@ Setting environment variables may be necessary to allow for importing/includes t
 
    : Enable the interactive debugger. See the [Interactive Debugger](/debugger) documentation for more information.
 
-     The optional ``FILE`` argument contains a list of debugger commands that are provided to the debugger as they were typed by the user.
+     The optional ``FILE`` argument contains a list of debugger commands that are provided to the debugger as if they were typed by the user.
 
      This option cannot be used with the ``--trace`` option.
 
@@ -62,15 +75,15 @@ Setting environment variables may be necessary to allow for importing/includes t
 
 ``-v, --verbose``
 
-   : Enable verbose mode and increment verbosity level. Each additional v provides a new level of information.
+   : Enable verbose mode and increment verbosity level. Each additional ``-v`` provides a new level of information.
 
 ``--version``
 
-   : Display the version of Daffodil.
+   : Display Daffodil's version.
 
-``--help``
+``-h, --help``
 
-   : Display help message.
+   : Display a help message.
 
 ### Parse Subcommand
 
@@ -78,9 +91,10 @@ Parse a file, using either a DFDL schema or a saved parser.
 
 #### Usage
 
-    daffodil parse (-s <schema> [-r [{<namespace>}]<root>] [-p <path>] | -P <parser>)
-                   [-D[{namespace}]<variable>=<value>...] [-T<tunable>=<value>] [-o <output>]
-                   [-V [mode]] [-c <file>] [-I <infoset_type>] [infile]
+    daffodil parse (-s <schema> [-r <root>] | -P <parser>)
+                   [-c <file>] [-D<variable>=<value>...] [-I <infoset_type>]
+                   [-o <output>] [--stream] [-T<tunable>=<value>...] [-V <mode>]
+                   [infile]
 
 #### Options
 
@@ -88,9 +102,9 @@ Parse a file, using either a DFDL schema or a saved parser.
 
    : XML file containing configuration items, such as external variables or Daffodil tunables. See [Configuration](/configuration) for details on the file format.
 
-``-D [{NAMESPACE}]VARIABLE=VALUE``
+``-D VARIABLE=VALUE``
 
-   : Variables to be used when parsing. ``VARIABLE`` can be prefixed with ``{NAMESPACE}`` to define which namespace the variable belongs in, for example:
+   : Variables to be used when parsing. A namespace may be specified by prefixing ``VARIABLE`` with ``{NAMESPACE}``, for example:
 
      ```-D{http://example.com}var1=var```
 
@@ -100,19 +114,15 @@ Parse a file, using either a DFDL schema or a saved parser.
 
 ``-o, --output FILE``
 
-   : Write output to a given ``FILE``. If the option is not given or ``FILE`` is -, output is written to standard out.
+   : Output file to write the infoset to. If the option is not given or ``FILE`` is -, the infoset is written to standard output.
 
 ``-P, --parser FILE``
 
-   : Use a previously saved parser, created using the save-parser subcommand. This option cannot be used with the ``--schema`` option or with the ``--validate`` option set to ``on``.
+   : Use a previously saved parser inside ``FILE``, created using the ``save-parser`` subcommand. This option cannot be used with the ``--schema`` option or with the ``--validate`` option set to ``on``.
 
-``-p, --path PATH``
+``-r, --root ROOT``
 
-   : The path to the node from the root element to create the parser from.
-
-``-r, --root [{NAMESPACE}]ROOT``
-
-   : The root element of the DFDL schema to use. This must be one of the top-level elements of the schema defined with ``--schema``. This requires the ``--schema`` option to be defined. If not supplied, the first element of the schema defined with ``--schema`` is used. A namespace may be specified by prefixing ``ROOT`` with ``{NAMESPACE}``.
+   : The root element to use. This must be one of the top-level elements of the DFDL schema defined with ``--schema``. This requires the ``--schema`` option to be defined. Defaults to the schema's first top-level element if not provided. A namespace may be specified by prefixing ``ROOT`` with ``{NAMESPACE}``.
 
 ``-s, --schema FILE``
 
@@ -122,25 +132,29 @@ Parse a file, using either a DFDL schema or a saved parser.
 
    : Rather than throwing an error when left over data exists after a parse, repeat the parse with the remaining data. Parsing repeats until end of data is reached, an error occurs, or no data is consumed. Output infosets are separated by a NUL character.
 
+``--nostream``
+
+   : Stop after the first parse, throwing an error if left over data exists. This is the default behavior.
+
 ``-T TUNABLE=VALUE``
 
-   : Modify Daffodil configuration options to change parsing behavior. See [Configuration](/configuration) for the list of tunable parameters.
+   : Tunable configuration options to change Daffodil's behavior. See [Configuration](/configuration) for the list of tunable parameters.
 
-``-V, --validate [MODE]``
+``-V, --validate MODE``
 
-   : The validation mode. ``MODE`` must be one of ``on``, ``limited`` or ``off``. If ``MODE`` is not provided, defaults to ``on``. If ``--validate`` is not provided, defaults to ``off``. ``MODE`` cannot be ``on`` when used with the ``--parser`` option.
+   : The validation mode. ``MODE`` must be one of ``on``, ``limited``, ``off``, or a validator plugin name. Defaults to ``off`` if not provided. Validator plugins are provided by SPI and are referenced here using the ``name`` defined by the plugin. ``MODE`` cannot be ``on`` when used with the ``--parser`` option.
 
 ``[INFILE]``
 
-   : Input file to parse. If not specified, or is a value of -, reads from standard in. If supplied, this must be the last option on the command line.
+   : Input file to parse. If not specified, or is a value of -, reads from standard input. If supplied, the input file must be the last option on the command line.
 
-``--help``
+``-h, --help``
 
-   : Display help message.
+   : Display a help message.
 
 #### Example
 
-    $ daffodil parse -s csv.dfdl.xsd test_file.csv
+    daffodil parse -s csv.dfdl.xsd test_file.csv
 
 ### Unparse Subcommand
 
@@ -148,9 +162,10 @@ Unparse an infoset file, using either a DFDL schema or a saved parser.
 
 #### Usage
 
-    daffodil unparse (-s <schema> [-r [{<namespace>}]<root>] [-p <path>] | -P <parser>)
-                     [-D[{<namespace>}]<variable>=<value>...] [-T<tunable>=<value>] [-o <output>]
-                     [-V [mode]] [-c <file>] [-I <infoset_type>] [infile]
+    daffodil unparse (-s <schema> [-r <root>] | -P <parser>)
+                     [-c <file>] [-D<variable>=<value>...] [-I <infoset_type>]
+                     [-o <output>] [--stream] [-T<tunable>=<value>...] [-V <mode>]
+                     [infile]
 
 #### Options
 
@@ -158,9 +173,9 @@ Unparse an infoset file, using either a DFDL schema or a saved parser.
 
    : XML file containing configuration items, such as external variables or Daffodil tunables. See [Configuration](/configuration) for details on the file format.
 
-``-D [{NAMESPACE}]VARIABLE=VALUE``
+``-D VARIABLE=VALUE``
 
-   : Variables to be used when unparsing. ``VARIABLE`` can be prefixed with ``{NAMESPACE}`` to define which namespace the variable belongs in, for example:
+   : Variables to be used when unparsing. A namespace may be specified by prefixing ``VARIABLE`` with ``{NAMESPACE}``, for example:
 
      ```-D{http://example.com}var1=var```
 
@@ -170,19 +185,15 @@ Unparse an infoset file, using either a DFDL schema or a saved parser.
 
 ``-o, --output FILE``
 
-   : Write output to a give ``FILE``. If the option is not given or ``FILE`` is -, output is written to standard out.
+   : Output file to write the data to. If the option is not given or ``FILE`` is -, the data is written to standard output.
 
 ``-P, --parser FILE``
 
-   : Use a previously saved parser, created using the save-parser subcommand. This option cannot be used with the ``--schema`` option or with the ``--validate`` option set to ``on``.
+   : Use a previously saved parser inside ``FILE``, created using the ``save-parser`` subcommand. This option cannot be used with the ``--schema`` option or with the ``--validate`` option set to ``on``.
 
-``-p, --path PATH``
+``-r, --root ROOT``
 
-   : The path to the node from the root element to create the parser from.
-
-``-r, --root [{NAMESPACE}]ROOT``
-
-   : The root element of the DFDL schema to use. This must be one of the top-level elements of the schema defined with ``--schema``. This requires the ``--schema`` option to be defined. If not supplied, the first element of the schema defined with ``--schema`` is used. A namespace may be specified by prefixing the ``ROOT`` with {NAMEAPSCE}.
+   : The root element to use. This must be one of the top-level elements of the DFDL schema defined with ``--schema``. This requires the ``--schema`` option to be defined. Defaults to the schema's first top-level element if not provided. A namespace may be specified by prefixing ``ROOT`` with ``{NAMESPACE}``.
 
 ``-s, --schema FILE``
 
@@ -192,24 +203,29 @@ Unparse an infoset file, using either a DFDL schema or a saved parser.
 
    : Split the input data at NUL characters and unparse each chunk separately to the same output file.
 
+``--nostream``
+
+   : Treat the entire input data as one infoset. This is the default behavior.
+
 ``-T TUNABLE=VALUE``
 
-   : Modify Daffodil configuration options to change parsing behavior. See [Configuration](/configuration) for the list of tunable parameters.
+   : Tunable configuration options to change Daffodil's behavior. See [Configuration](/configuration) for the list of tunable parameters.
 
-``-V, --validate [MODE]``
+``-V, --validate MODE``
 
-  : The validation mode. ``MODE`` must be one of ``on``, ``limited`` or ``off``. If ``MODE`` is not provided, defaults to ``on``. If ``--validate`` is not provided, defaults to ``off``. ``MODE`` cannot be ``on`` when used with the ``--parser`` option.
+   : The validation mode. ``MODE`` must be one of ``on``, ``limited``, ``off``, or a validator plugin name. Defaults to ``off`` if not provided. Validator plugins are provided by SPI and are referenced here using the ``name`` defined by the plugin. ``MODE`` cannot be ``on`` when used with the ``--parser`` option.
 
 ``[INFILE]``
 
-   : Input file to unparse. If not specified, or is a value of -, reads from standard in. If supplied, this must be the last option on the command line.
+   : Input file to unparse. If not specified, or is a value of -, reads from standard input. If supplied, the input file must be the last option on the command line.
 
-``--help``
-   : Display help message.
+``-h, --help``
+
+   : Display a help message.
 
 #### Example
 
-    $ daffodil unparse -s csv.dfdl.xsd test_file.infoset
+    daffodil unparse -s csv.dfdl.xsd test_file.infoset
 
 ### Save Parser Subcommand
 
@@ -217,7 +233,9 @@ Save a parser that can be reused for parsing and unparsing.
 
 #### Usage
 
-    daffodil save-parser -s <schema> [-r [{namespace}]<root>] [-p <path>] [outfile]
+    daffodil save-parser -s <schema> [-r <root>]
+                        [-c <file>] [-D<variable>=<value>...] [-T<tunable>=<value>...]
+                        [outfile]
 
 #### Options
 
@@ -225,19 +243,15 @@ Save a parser that can be reused for parsing and unparsing.
 
    : XML file containing configuration items, such as external variables or Daffodil tunables. See [Configuration](/configuration) for details on the file format.
 
-``-D [{NAMESPACE}]VARIABLE=VALUE``
+``-D VARIABLE=VALUE``
 
-   : Variables to be used when parsing. ``VARIABLE`` can be prefixed with ``{NAMESPACE}`` to define which namespace the variable belongs in, for example:
+   : Variables to be used when parsing or unparsing. A namespace may be specified by prefixing ``VARIABLE`` with ``{NAMESPACE}``, for example:
 
      ```-D{http://example.com}var1=var```
 
-``-p, --path PATH``
+``-r, --root ROOT``
 
-   : The path to the node from the root element to create the parser from.
-
-``-r, --root [{NAMESPACE}]ROOT``
-
-   : The root element of the DFDL schema to use. This must be one of the top-level elements of the schema defined with ``--schema``. This requires the ``--schema`` option to be defined. If not supplied, the first element of the schema defined with ``--schema`` is used. A namespace may be specified by prefixing ``ROOT`` with ``{NAMESPACE}``.
+   : The root element to use. This must be one of the top-level elements of the DFDL schema defined with ``--schema``. This requires the ``--schema`` option to be defined. Defaults to the schema's first top-level element if not provided. A namespace may be specified by prefixing ``ROOT`` with ``{NAMESPACE}``.
 
 ``-s, --schema FILE``
 
@@ -245,23 +259,19 @@ Save a parser that can be reused for parsing and unparsing.
 
 ``-T TUNABLE=VALUE``
 
-   : Modify Daffodil configuration options to change parsing behavior. See [Configuration](/configuration) for the list of tunable parameters.
-
-``-V, --validate MODE``
-
-   : The validation mode. ``MODE`` must be either ``limited`` or ``off``. ``MODE`` is required. If ``--validate`` is not present, defaults to ``off``. ``MODE`` cannot be set to ``on`` as possible in other commands.
+   : Tunable configuration options to change Daffodil's behavior. See [Configuration](/configuration) for the list of tunable parameters.
 
 ``[OUTFILE]``
 
-   : Write the parser to a give file. If the option is not given or is -, output is written to standard out. If supplied, this must be the last option on the command line.
+   : Output file to save the parser to. If the option is not given or is -, the parser is saved to standard output. If supplied, the output file must be the last option on the command line.
 
-``--help``
+``-h, --help``
 
-   : Display help message.
+   : Display a help message.
 
 #### Example
 
-    $ daffodil save-parser -s csv.dfdl.xsd csv_parser.xml
+    daffodil save-parser -s csv.dfdl.xsd csv_parser.xml
 
 ### Test Subcommand
 
@@ -269,47 +279,49 @@ List or execute tests in a TDML file.
 
 #### Usage
 
-    daffodil test [-l] [-r] [-i] <tdmlfile> [testname...]
+    daffodil test [-l] [-r] [-i] <tdmlfile> [testnames...]
 
 #### Options
 
 ``-i, --info``
 
-   : Increment test result information output level, one level for each occurrence of -i.
+   : Increment test result information output level, one level for each -i.
 
 ``-l, --list``
 
-   : Show names and descriptions in a TDML file instead of running them.
+   : Show names and descriptions of test cases in a TDML file instead of running them.
 
 ``-r, --regex``
 
-   : Treat ``TESTNAME``s as regular expressions.
+   : Treat ``TESTNAMES...`` as regular expressions.
 
 ``TDMLFILE``
 
    : Test Data Markup Language (TDML) file.
 
-``[TESTNAME...]``
+``[TESTNAMES...]``
 
-   : Name of one or more test case in the TDML file. If not given, all tests in ``TDMLFILE`` are run.
+   : Name(s) of test cases in the TDML file. If not given, all tests in ``TDMLFILE`` are run.
 
-``--help``
+``-h, --help``
 
-   : Display help message.
+   : Display a help message.
 
 #### Example
 
-    $ daffodil test csv.tdml
+    daffodil test csv.tdml
 
 ### Performance Subcommand
 
-Run a performance test (parse or unparse), using either a DFDL schema or a saved parser
+Run a performance test (parse or unparse), using either a DFDL schema or a saved parser.
 
 #### Usage
 
-    daffodil performance (-s <schema> [-r [{namespace}]<root>] [-p <path>] |  -P <parser)
-                         [-u] [-V[mode]] [-N <number>] [-t <threads>]
-                         [-D[{namespace}]<variable>=<value>] [-I <infoset_type>] <infile>
+    daffodil performance (-s <schema> [-r <root>] | -P <parser>)
+                         [-c <file>] [-D<variable>=<value>...] [-I <infoset_type>]
+                         [-N <number>] [-t <threads>] [-T<tunable>=<value>...]
+                         [-u] [-V <mode>]
+                         <infile>
 
 #### Options
 
@@ -317,31 +329,27 @@ Run a performance test (parse or unparse), using either a DFDL schema or a saved
 
    : XML file containing configuration items, such as external variables or Daffodil tunables. See [Configuration](/configuration) for details on the file format.
 
-``-D [{NAMESPACE}]VARIABLE=VALUE``
+``-D VARIABLE=VALUE``
 
-   : Variables to be used when parsing. ``VARIABLE`` can be prefixed with ``{NAMESPACE}`` to define which namespace the variable belongs in, for example:
+   : Variables to be used when parsing or unparsing. ``VARIABLE`` can be prefixed with ``{NAMESPACE}`` to define which namespace the variable belongs in, for example:
 
      ```-D{http://example.com}var1=var```
 
 ``-I, --infoset-type TYPE``
 
-   : Infoset type to parse/unparse. ``TYPE`` must be one of ``xml``, ``scala-xml``, ``json``, ``jdom``, ``sax``, or ``null``. Defaults to ``xml`` if not provided. Note that ``null`` is not valid if the ``--unparse`` option is provided.
+   : Infoset type to output or unparse. ``TYPE`` must be one of ``xml``, ``scala-xml``, ``json``, ``jdom``, ``sax``, or ``null``. Defaults to ``xml`` if not provided. Note that ``null`` is not valid if the ``--unparse`` option is provided.
 
 ``-N, --number NUMBER``
 
-   : Total number of files to process. Defaults to 1.
+   : The total number of files to process. Defaults to 1.
 
 ``-P, --parser FILE``
 
-   : Use a previously saved parser, created using the save-parser subcommand. This option cannot be used with the ``--schema`` option or with the ``--validate`` option set to ``on``.
+   : Use a previously saved parser inside ``FILE``, created using the ``save-parser`` subcommand. This option cannot be used with the ``--schema`` option or with the ``--validate`` option set to ``on``.
 
-``-p, --path PATH``
+``-r, --root ROOT``
 
-   : The path to the node from the root element to create the parser from.
-
-``-r, --root [{NAMESPACE}]ROOT``
-
-   : The root element of the DFDL schema to use. This must be one of the top-level elements of the schema defined with ``--schema``. This requires the ``--schema`` option to be defined. If not supplied, the first element of the schema defined with ``--schema`` is used. A namespace may be specified by prefixing ``ROOT`` with ``{NAMESPACE}``.
+   : The root element to use. This must be one of the top-level elements of the DFDL schema defined with ``--schema``. This requires the ``--schema`` option to be defined. Defaults to the schema's first top-level element if not provided. A namespace may be specified by prefixing ``ROOT`` with ``{NAMESPACE}``.
 
 ``-s, --schema FILE``
 
@@ -353,24 +361,68 @@ Run a performance test (parse or unparse), using either a DFDL schema or a saved
 
 ``-T TUNABLE=VALUE``
 
-   : Modify Daffodil configuration options to change processing behavior. See [Configuration](/configuration) for the list of tunable parameters.
+   : Tunable configuration options to change Daffodil's behavior. See [Configuration](/configuration) for the list of tunable parameters.
 
 ``-u, --unparse``
 
-   : Perform unparse instead of parse for performance.
+   : Perform unparse instead of parse for performance test.
 
-``-V, --validate [MODE]``
+``-V, --validate MODE``
 
-   : The validation mode. ``on``, ``limited`` or ``off``. If ``MODE`` is not provided, defaults to ``on``. If ``--validate`` is not provided, defaults to ``off``. ``MODE`` cannot be ``on`` when used with the ``--parser`` option.
+   : The validation mode. ``MODE`` must be one of ``on``, ``limited``, ``off``, or a validator plugin name. Defaults to ``off`` if not provided. Validator plugins are provided by SPI and are referenced here using the ``name`` defined by the plugin. ``MODE`` cannot be ``on`` when used with the ``--parser`` option.
 
-``[INFILE]``
+``INFILE``
 
-   : Input file or directory containing files to process
+   : Input file or directory containing input files to parse or unparse. Required argument.
 
-``--help``
+``-h, --help``
 
-   : Display help message.
+   : Display a help message.
 
 #### Example
 
-    $ daffodil performance -s csv.dfdl.xsd -N 1000 -t 5 test_file.csv
+    daffodil performance -s csv.dfdl.xsd -N 1000 -t 5 test_file.csv
+
+### Generate Subcommand
+
+Generate C code from a DFDL schema to parse or unparse data.
+
+#### Usage
+
+    daffodil generate <language> [SUBCOMMAND_OPTS]
+
+    --- there is only one choice for <language> at this time ---
+
+    daffodil generate c -s <schema> [-r <root>]
+                        [-c <file>] [-T<tunable>=<value>...]
+                        [outdir]
+
+#### Options
+
+``-c, --config FILE``
+
+   : XML file containing configuration items, such as external variables or Daffodil tunables. See [Configuration](/configuration) for details on the file format.
+
+``-r, --root ROOT``
+
+   : The root element to use. This must be one of the top-level elements of the DFDL schema defined with ``--schema``. This requires the ``--schema`` option to be defined. Defaults to the schema's first top-level element if not provided. A namespace may be specified by prefixing ``ROOT`` with ``{NAMESPACE}``.
+
+``-s, --schema FILE``
+
+   : The annotated DFDL schema to use to generate C code. This option must be supplied.
+
+``-T TUNABLE=VALUE``
+
+   : Tunable configuration options to change Daffodil's behavior. See [Configuration](/configuration) for the list of tunable parameters.
+
+``[OUTDIR]``
+
+   : The output directory in which to create or replace a `c` subdirectory containing the generated C code. If the option is not given, a `c` subdirectory within the current directory will be created/replaced. If supplied, the output directory must be the last option on the command line.
+
+``-h, --help``
+
+   : Display a help message.
+
+#### Example
+
+    daffodil generate c -s csv.dfdl.xsd


### PR DESCRIPTION
Fix or disable markdownlint warnings.

Convert list of subcommands to bullets.

Document new "generate" subcommand.

Add CC environment variable, clarifying "test" subcommand will use CC
environment variable if testing runtime2.  Also mention Daffodil will
pick first driver command it finds within PATH from a list if CC
environment variable is not defined.

Compare CLI documentation with Daffodil's in-program CLI help
information and make them match each other better, such as sorting
essential usage options first and then rest of options alphabetically.

Proofread CLI documentation and reword some phrases to improve
readability and consistency.

Remove confusing [{<namespace>}] from -D and -r options.

Remove -p, --path option since Daffodil allows only "/".

Add validator plugin name to validation modes and clarify validation
mode is not optional anymore.  Remove validation option from
save-parser since it doesn't support that option.

Rename testname to testnames for consistency.

Add "Defaults to" in more places.

DAFFODIL-817, DAFFODIL-2477