### PR TITLE
Only publish site updates from the master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           jekyll build --source site
 
       - name: Publish
-        if: github.repository == 'apache/daffodil-site'
+        if: ${{ github.repository == 'apache/daffodil-site' && github.ref == 'refs/heads/master' }}
         run: |
           git checkout asf-site
           rm -rf content


### PR DESCRIPTION
We currently enable the publish action when commits are made directly to
the apache/daffodil-site repo. This prevents publishing pull requests
until they are merged. However, if we push a branch directly to
apache/daffodil-site for a pull request rather than a fork, then this
action is still triggered, and we will publish from the branch. We don't
want that. We only want to ever publish commits made to the master
branch of the apache/daffodil repo. This fixes that.