### PR TITLE
Update 3.1.0 release notes

### DIFF
--- a/site/_releases/3.1.0.md
+++ b/site/_releases/3.1.0.md
@@ -6,7 +6,7 @@ title: 3.1.0
 date: 2021-05-12
 summary: >
     Code generation backend, Schematron validation, variable improvements,
-    imporoved SAX conformance and performance, miscellaneous bug fixes and
+    improved SAX conformance and performance, miscellaneous bug fixes and
     improvements
 
 artifact-root: "https://dist.apache.org/repos/dist/dev/daffodil/3.1.0-rc1/"
@@ -14,13 +14,13 @@ checksum-root: "https://dist.apache.org/repos/dist/dev/daffodil/3.1.0-rc1/"
 key-file: "https://downloads.apache.org/daffodil/KEYS"
 
 source-dist:
-    - "apache-daffodil-3.1.0-incubating-src.zip"
+    - "apache-daffodil-3.1.0-src.zip"
 
 binary-dist:
-    - "apache-daffodil-3.1.0-incubating-bin.tgz"
-    - "apache-daffodil-3.1.0-incubating-bin.zip"
-    - "apache-daffodil-3.1.0-incubating-bin.msi"
-    - "apache-daffodil-3.1.0.incubating-1.noarch.rpm"
+    - "apache-daffodil-3.1.0-bin.tgz"
+    - "apache-daffodil-3.1.0-bin.zip"
+    - "apache-daffodil-3.1.0-bin.msi"
+    - "apache-daffodil-3.1.0-1.noarch.rpm"
 
 scala-version: 2.12
 ---
@@ -95,8 +95,8 @@ namespace/prefix properties and improved unparse performance.
 * {% jira 2431 %} CSV data causes abort
 * {% jira 2432 %} Need validation of tunable values
 * {% jira 2455 %} Large CSV file causes "Attempting to backtrack too far" exception
-* {% jira 2461 %} Intermittant test failure in schematron CLI tests
-* {% jira 2468 %} Uparsing an infoset for an 800mb csv file runs out of memory
+* {% jira 2461 %} Intermittent test failure in schematron CLI tests
+* {% jira 2468 %} Unparsing an infoset for an 800mb csv file runs out of memory
 * {% jira 2487 %} parser hangs on row with initial empty field in CSV-like data
 * {% jira 2492 %} Test fails on non-US locale
 * {% jira 2494 %} Fix user unfriendly issues with recent jline upgrade
@@ -111,7 +111,7 @@ namespace/prefix properties and improved unparse performance.
 * {% jira 1503 %} Warning needed for length="0" being ignored.
 * {% jira 1605 %} Update Wiki based on CII best practices review
 * {% jira 2144 %} Standard schema project layout - suggested build.sbt is outdated
-* {% jira 2360 %} Comitted files that match .gitignore patterns
+* {% jira 2360 %} Committed files that match .gitignore patterns
 * {% jira 2430 %} ratCheck fails when run from the sbt console
 * {% jira 2434 %} Update sbt-rat plugin to 0.7.0
 * {% jira 2435 %} Prepare for 3.1.0
@@ -121,7 +121,7 @@ namespace/prefix properties and improved unparse performance.
 * {% jira 2453 %} Debugger: support for displaying variable information
 * {% jira 2454 %} Eclipse - Not able to Compile or Daffodil/stage daffodil 3.0.0
 * {% jira 2463 %} Update Daffodil Incubator Status file/page
-* {% jira 2464 %} Document Apache Daffodil Maturity Model Assesment
+* {% jira 2464 %} Document Apache Daffodil Maturity Model Assessment
 * {% jira 2465 %} Remove requirement of DAFFODIL\_HOME for eclipse setup
 * {% jira 2467 %} Bump copyright years to 2021
 * {% jira 2469 %} Need to update unsupported features page
@@ -142,7 +142,7 @@ A number of issues remain open that have been marked as critical, and are
 expected to be fixed in the next release. These issues are:
 
 * {% jira 1422 %} disallow doctype decls in all XML & XSD that we read in
-* {% jira 2400 %} New SAX API causes performance degredations.
+* {% jira 2400 %} New SAX API causes performance degradations
 * {% jira 2512 %} Unordered sequences with initiated content or discriminators does not parse correctly
 
 #### Deprecation/Compatibility
@@ -176,10 +176,10 @@ The following dependencies have been added or updated
 **Code Generator (runtime2)**
 
 * OS-Lib 0.7.6 <small>(new)</small>
-* Lightbend Config 1.4.1 <small>(new)</small>
 
 **Schematron Validator**
 
+* Lightbend Config 1.4.1 <small>(new)</small>
 * Saxon-HE 10.5 <small>(new)</small>
 
 **Test**


### PR DESCRIPTION
Remove "incubating" from filenames.

Put "Lightbend Config" under Schematron Validator, not Code Generator.

Fix typos (can reject this if you want jiras and titles to match).