### PR TITLE
Add .asf.yml to publish the website

### DIFF
--- a/.asf.yml
+++ b/.asf.yml
@@ -1,0 +1,2 @@
+publish:
+  whoami: asf-site 


### PR DESCRIPTION
ASF Infra is deprecating the gitwcsub method of publishing git websites.
Instead, we need to put an .asf.yml file with 'publish/whoami' in the
branch we want to publish.