### PR TITLE
Fix a missed master to main rename

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           jekyll build --source site
 
       - name: Publish
-        if: ${{ github.repository == 'apache/daffodil-site' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository == 'apache/daffodil-site' && github.ref == 'refs/heads/main' }}
         run: |
           git checkout asf-site
           rm -rf content


### PR DESCRIPTION
Commit ede2e85bf542c0b2a98fc14b831571b0f68cc2c8 renamed master to main
but missed an instance due to a grep that missed hidden files. This
caused the site to not be published once the commit was merged. Fixed
the grep and found only this one instance.

DAFFODIL-2557