### PR TITLE
Use a generic name/email for website publish commit author

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           rm -rf content
           mv target content
           git add content
-          git config --local user.email "${{ github.event.head_commit.committer.email }}"
-          git config --local user.name "${{ github.event.head_commit.committer.name }}"
+          git config --local user.email "dev@daffodil.apache.org"
+          git config --local user.name "Apache Daffodil Site Autobuild"
           git commit -a --allow-empty -m "Publishing from ${{ github.sha }}"
           git push --force "https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git" asf-site


### PR DESCRIPTION
When committing website content in the Github publish workflow, we use
the github.event.head_commit.committer.name/email values, which should
be the name/email of the committer of the change. But sometimes it uses
the name/email associated with the account who merged the account (I
think), which is not necessarily the correct information. In my case,
its uses a personal email instead of an @apache.org email. Since this
doesn't information doesn't really matter, and since it's an automated
commit, switch to using dev@daffodil.apache.org and a generic Daffodil
name when committing changes to the asf-site branch.