### PR TITLE
Add VSCode to Site

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -25,11 +25,16 @@ collections:
     releases:
         output: true
         permalink: /releases/:title/
+    vscode:
+      output: true
+      permalink: /vscode/:title/
 
 # Site-wide defaults
 defaults:
     - scope:  { type: releases }
       values: { layout: release }
+    - scope:  { type: vscode }
+      values: { layout: vscode }
 
 # Used by the JIRA plugin
 jira_base_url: https://issues.apache.org/jira/browse

--- a/site/_includes/themes/apache/_navigation.html
+++ b/site/_includes/themes/apache/_navigation.html
@@ -4,6 +4,7 @@
         <nav role="navigation">
           <ul class="nav navbar-nav navbar-right">
             <li><a href="/releases">Releases</a></li>
+            <li><a href="/vscode">VSCode</a></li>
             <li id="documentation">
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Docs<b class="caret"></b></a>
               <ul class="dropdown-menu dropdown-left">

--- a/site/_layouts/vscode.html
+++ b/site/_layouts/vscode.html
@@ -1,0 +1,70 @@
+---
+layout: default
+permalink: /vscode/release-notes-:title
+---
+
+{% unless page.released %}
+  <div class="alert alert-warning">
+    Apache Daffodil VSCode {{ page.title }} has not yet been released! The artifacts
+    and release notes below are drafts for a proposed release of Apache
+    Daffodil which has not yet occurred.
+  </div>
+{% endunless %}
+
+<div class="row">
+  <div class="col-md-12">
+    <h3>Get Release</h3>
+    <ul class="nav nav-tabs">
+      <li class="active"><a data-toggle="tab" href="#download">Download</a></li>
+    </ul>
+    <div class="tab-content">
+      <div id="download" class="tab-pane fade in active">
+        {% if page.source-dist %}
+          {% if page.apache %} {% assign prefix = "src/" %} {% endif %}
+          <h4>Source</h4>
+          <p>
+          {% include download-list.html
+             version=page.title
+             artifacts=page.source-dist
+             checksum-root=page.checksum-root
+             artifact-root=page.artifact-root
+             prefix=prefix
+          %}
+          </p>
+        {% endif %}
+
+        {% if page.binary-dist %}
+          {% if page.apache %} {% assign prefix = "bin/" %} {% endif %}
+          <h4>Binaries</h4>
+          <p>
+          {% include download-list.html
+             version=page.title
+             artifacts=page.binary-dist
+             checksum-root=page.checksum-root
+             artifact-root=page.artifact-root
+             prefix=prefix
+          %}
+          </p>
+        {% endif %}
+
+        {% if page.apache %}
+          <hr />
+          <p>
+            <i>
+              The above release files should be verified using the PGP signatures and the
+              <a href='{{ page.key-file }}'>project release KEYS</a>. See
+              <a href='https://www.apache.org/dyn/closer.cgi#verify'>verification instructions</a>
+              for a description of using the PGP and KEYS files for
+              verification. A SHA512 checksum is also provided as
+              an alternative verification method.
+            </i>
+          </p>
+        {% endif page.apache %}
+      </div>
+    </div>
+  </div>
+</div>
+
+<h3 id="release-notes">Release Notes</h3>
+
+{{ content }}

--- a/site/_vscode/1.0.0.md
+++ b/site/_vscode/1.0.0.md
@@ -1,0 +1,28 @@
+---
+
+released: true
+apache: true
+title: 1.0.0
+date: 2022-03-17
+summary: >
+    Initial release
+
+artifact-root: "https://dist.apache.org/repos/dist/dev/daffodil/daffodil-vscode/1.0.0-rc2/"
+checksum-root: "https://dist.apache.org/repos/dist/dev/daffodil/daffodil-vscode/1.0.0-rc2/"
+
+key-file: "https://downloads.apache.org/daffodil/KEYS"
+
+source-dist:
+    - "apache-daffodil-vscode-1.0.0-src.zip"
+
+binary-dist:
+    - "apache-daffodil-vscode-1.0.0.vsix"
+
+scala-version: 2.13
+---
+
+This release contains VSCode extension used parsing/debugging a daffodil schema inside of VSCode.
+
+#### v1.0.0
+
+[GitHub v1.0.0 Closed Issues](https://github.com/apache/daffodil-vscode/issues?q=is%3Aissue+is%3Aclosed)

--- a/site/vscode.md
+++ b/site/vscode.md
@@ -1,0 +1,74 @@
+---
+layout: page
+title: VSCode Extension
+group: nav-right
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+#### Summary
+This page is for the Daffodil VSCode Extension. 
+
+Features:
+
+* DFDL schema parsing/debugging
+* Output infoset to console, file or none
+* Session launch configuration
+* Scala implementation of the daffodil debugger
+* View infoset while debugging
+* View difference of infoset from one step to another when debugging
+* View hex of the data file
+* Launch wizard, helps create the `.vscode/launch.json`
+* Run currently opened schema file
+* Debug currently opened schema file
+* Daffodil toolbar and Command Palette:
+    * Open infoset view
+    * Open infoset diff view
+    * Open hex view
+    * Open launch wizard
+* Set breakpoints inside of main schema file
+* Set breakpoints inside of imported schemas
+
+#### Releases
+
+All recent Daffodil VSCode Extension releases are listed here. Each release below is listed by the version and date on which it was released. Clicking on the version number will take you to the release notes and downloads for that release.
+
+{% assign releases = site.vscode  | where: 'released', 'true' | where: 'apache', 'true' | sort: 'date' %}
+{% if releases.size > 0 %}
+<table class="table">
+    <tr>
+        <th class="col-md-1">Version</th>
+        <th>Summary</th>
+        <th class="col-md-2 text-right">Release&nbsp;Date</th>
+    </tr>
+    {% for release in releases reversed %}
+        {% if release.title %}
+            <tr>
+                <td style="vertical-align: middle; line-height: 2.5em;" class="col-md-1"><a href="{{ release.url | prepend: site.baseurl }}">{{ release.title }}</a></td>
+                <td style="vertical-align: middle;">{{ release.summary }}</td>
+                <td style="vertical-align: middle;" class="col-md-2 text-right">{{ release.date | date: "%Y-%m-%d" }}</td>
+            </tr>
+        {% endif %}
+    {% endfor %}
+</table>
+{% else %}
+<div class="alert alert-warning">
+No official Apache releases have been made yet. <a href="/community">Get involved</a> and help us on our way!
+</div>
+{% endif %}


### PR DESCRIPTION
Update daffodil-site to add page for the VSCode extension:

- Create site/vscode.md
- Create site/_vscode to hold all the releases
- Create site/_vscode/1.0.0.md - release file for 1.0.0
- Create navigation item for the VSCode page
- Create site/_layouts/vscode.html
- Update site/_config.yml to map vscode page