### PR TITLE
WIP: User doc on packaging and plugins. Drafts

### DIFF
--- a/site/_data/contributors.yml
+++ b/site/_data/contributors.yml
@@ -109,3 +109,10 @@
   githubId: scholarsmate
   role: PMC
 
+- first: Mike
+  last: McGann
+  apacheId: mmcgann
+  githubId: mike-mcgann
+  role: PMC
+
+


### PR DESCRIPTION
First draft of pages about packaging dfdl schemas, and about plugins.

All applications using Daffodil, at least via Runtime1 should, ideally, be taking advantage of packaging DFDL schemas in Jar files, using 'sbt publish' and managed-dependencies for inter-schema dependencies, etc.