### PR TITLE
Update VS Code 1.2.0 summary

### DIFF
--- a/site/_vscode/1.2.0.md
+++ b/site/_vscode/1.2.0.md
@@ -5,7 +5,8 @@ apache: true
 title: 1.2.0
 date: 2022-12-06
 summary: >
-    Initial omega-edit client & DFDL language
+    Testing, omega-edit, intellisense, configuration and debugging
+    improvements. Along with package upgrades and bug fixes.
 
 artifact-root: "https://www.apache.org/dyn/closer.lua/daffodil/daffodil-vscode/1.2.0/"
 checksum-root: "https://downloads.apache.org/daffodil/daffodil-vscode/1.2.0/"


### PR DESCRIPTION
Quick fix to make the 1.2.0 summary not be the same as 1.1.0's