### PR TITLE
Update release artifact and checksum URLs

### DIFF
--- a/site/_includes/download-list.html
+++ b/site/_includes/download-list.html
@@ -1,13 +1,28 @@
-{% for file in include.artifacts %}
+{% assign apache = include.apache %}
+{% assign artifacts = include.artifacts %}
+{% assign project = include.project %}
+{% assign type = include.type %}
+{% assign version = include.version %}
+
+{% for file in artifacts %}
+  {% if apache %}
+    {% if file contains "incubating" %}
+      {% assign project = "incubator/" | append: project %}
+    {% endif %}
+    {% capture file-path %}{{project}}/{{version}}/{{type}}/{{file}}{% endcapture %}
+    {% capture artifact-url %}https://www.apache.org/dyn/closer.lua/download/{{file-path}}{% endcapture %}
+    {% capture checksum-url %}https://downloads.apache.org/{{file-path}}{% endcapture %}
+  {% else %}
+    {% capture artifact-url %}https://opensource.ncsa.illinois.edu/projects/artifacts.php?key=DFDL&version={{version}}&filename={{file}}{% endcapture %}
+  {% endif %}
 <div class="row">
   <div class="col-sm-6">
-    <a href="{{ include.artifact-root | append: include.prefix | append: file }}">{{ file }}</a>
+    <a href="{{ artifact-url }}">{{ file }}</a>
   </div>
   <div class="col-sm-6">
-    {% if include.checksum-root %}
-      {% assign base = include.checksum-root | append: include.prefix | append: file %}
-      [ <a href="{{ base }}.asc">PGP</a> ]
-      [ <a href="{{ base }}.sha512">SHA512</a> ]
+    {% if checksum-url %}
+      [ <a href="{{ checksum-url }}.asc">PGP</a> ]
+      [ <a href="{{ checksum-url }}.sha512">SHA512</a> ]
     {% endif %}
   </div>
 </div>

--- a/site/_layouts/release.html
+++ b/site/_layouts/release.html
@@ -36,29 +36,27 @@ permalink: /release/release-notes-:title
     <div class="tab-content">
       <div id="download" class="tab-pane fade in active">
         {% if page.source-dist %}
-          {% if page.apache %} {% assign prefix = "src/" %} {% endif %}
           <h4>Source</h4>
           <p>
           {% include download-list.html
-             version=page.title
+             apache=page.apache
              artifacts=page.source-dist
-             checksum-root=page.checksum-root
-             artifact-root=page.artifact-root
-             prefix=prefix
+             project="daffodil"
+             type="src"
+             version=page.title
           %}
           </p>
         {% endif %}
 
         {% if page.binary-dist %}
-          {% if page.apache %} {% assign prefix = "bin/" %} {% endif %}
           <h4>Binaries</h4>
           <p>
           {% include download-list.html
-             version=page.title
+             apache=page.apache
              artifacts=page.binary-dist
-             checksum-root=page.checksum-root
-             artifact-root=page.artifact-root
-             prefix=prefix
+             project="daffodil"
+             type="bin"
+             version=page.title
           %}
           </p>
         {% endif %}
@@ -68,8 +66,8 @@ permalink: /release/release-notes-:title
           <p>
             <i>
               The above release files should be verified using the PGP signatures and the
-              <a href='{{ page.key-file }}'>project release KEYS</a>. See
-              <a href='https://www.apache.org/dyn/closer.cgi#verify'>verification instructions</a>
+              <a href='https://downloads.apache.org/daffodil/KEYS'>project release KEYS</a>. See
+              <a href='https://www.apache.org/info/verification.html'>verification instructions</a>
               for a description of using the PGP and KEYS files for
               verification. A SHA512 checksum is also provided as
               an alternative verification method.

--- a/site/_layouts/vscode.html
+++ b/site/_layouts/vscode.html
@@ -21,29 +21,27 @@ permalink: /vscode/release-notes-:title
     <div class="tab-content">
       <div id="download" class="tab-pane fade in active">
         {% if page.source-dist %}
-          {% if page.apache %} {% assign prefix = "src/" %} {% endif %}
           <h4>Source</h4>
           <p>
           {% include download-list.html
-             version=page.title
+             apache=page.apache
              artifacts=page.source-dist
-             checksum-root=page.checksum-root
-             artifact-root=page.artifact-root
-             prefix=prefix
+             project="daffodil/daffodil-vscode"
+             type="src"
+             version=page.title
           %}
           </p>
         {% endif %}
 
         {% if page.binary-dist %}
-          {% if page.apache %} {% assign prefix = "bin/" %} {% endif %}
           <h4>Binaries</h4>
           <p>
           {% include download-list.html
+             apache=page.apache
+             artifacts=page.source-dist
+             project="daffodil/daffodil-vscode"
+             type="bin"
              version=page.title
-             artifacts=page.binary-dist
-             checksum-root=page.checksum-root
-             artifact-root=page.artifact-root
-             prefix=prefix
           %}
           </p>
         {% endif %}
@@ -53,8 +51,8 @@ permalink: /vscode/release-notes-:title
           <p>
             <i>
               The above release files should be verified using the PGP signatures and the
-              <a href='{{ page.key-file }}'>project release KEYS</a>. See
-              <a href='https://www.apache.org/dyn/closer.cgi#verify'>verification instructions</a>
+              <a href='https://downloads.apache.org/daffodil/KEYS'>project release KEYS</a>. See
+              <a href='https://www.apache.org/info/verification.html'>verification instructions</a>
               for a description of using the PGP and KEYS files for
               verification. A SHA512 checksum is also provided as
               an alternative verification method.

--- a/site/_releases/1.0.0.md
+++ b/site/_releases/1.0.0.md
@@ -7,8 +7,6 @@ date: 2015-03-02
 summary: >
     Parse support for most features of the DFDL specification
 
-artifact-root: "https://opensource.ncsa.illinois.edu/projects/artifacts.php?key=DFDL&version=1.0.0&filename="
-
 binary-dist:
     - "daffodil-1.0.0.zip"
     - "daffodil-1.0.0.tgz"

--- a/site/_releases/1.1.0.md
+++ b/site/_releases/1.1.0.md
@@ -7,8 +7,6 @@ date: 2015-06-04
 summary: >
     Unparse support for simple text data formats
 
-artifact-root: "https://opensource.ncsa.illinois.edu/projects/artifacts.php?key=DFDL&version=1.1.0&filename="
-
 binary-dist:
     - "daffodil-1.1.0.zip"
     - "daffodil-1.1.0.tgz"

--- a/site/_releases/2.0.0.md
+++ b/site/_releases/2.0.0.md
@@ -7,8 +7,6 @@ date: 2017-09-05
 summary: >
     Support for unparse, with one-to-one feature parity with parse
 
-artifact-root: "https://opensource.ncsa.illinois.edu/projects/artifacts.php?key=DFDL&version=2.0.0&filename="
-
 binary-dist:
     - "daffodil-2.0.0.zip"
     - "daffodil-2.0.0.tgz"

--- a/site/_releases/2.1.0.md
+++ b/site/_releases/2.1.0.md
@@ -8,10 +8,6 @@ summary: >
     Apache incubation/relicensing, packed decimal support, ambiguous expression
     support, refactoring for future performance improvements
 
-artifact-root: "https://archive.apache.org/dist/incubator/daffodil/2.1.0/"
-checksum-root: "https://archive.apache.org/dist/incubator/daffodil/2.1.0/"
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-2.1.0-incubating-src.zip"
 

--- a/site/_releases/2.2.0.md
+++ b/site/_releases/2.2.0.md
@@ -7,10 +7,6 @@ date: 2018-09-04
 summary: >
     Message-Streaming API, numerous bug fixes, and features to support additional DFDL schemas.
 
-artifact-root: "https://archive.apache.org/dist/incubator/daffodil/2.2.0/"
-checksum-root: "https://archive.apache.org/dist/incubator/daffodil/2.2.0/"
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-2.2.0-incubating-src.zip"
 

--- a/site/_releases/2.3.0.md
+++ b/site/_releases/2.3.0.md
@@ -7,10 +7,6 @@ date: 2019-02-26
 summary: >
     New features, changes, and bug fixes to improve IBM DFDL compatability
 
-artifact-root: "https://archive.apache.org/dist/incubator/daffodil/2.3.0/"
-checksum-root: "https://archive.apache.org/dist/incubator/daffodil/2.3.0/"
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-2.3.0-incubating-src.zip"
 

--- a/site/_releases/2.4.0.md
+++ b/site/_releases/2.4.0.md
@@ -8,10 +8,6 @@ summary: >
     Improved DFDL schema compatibility, new extensions, explicit length
     choices, better DFDL schema validation, and many bug fixes.
 
-artifact-root: "https://archive.apache.org/dist/incubator/daffodil/2.4.0/"
-checksum-root: "https://archive.apache.org/dist/incubator/daffodil/2.4.0/"
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-2.4.0-incubating-src.zip"
 

--- a/site/_releases/2.5.0.md
+++ b/site/_releases/2.5.0.md
@@ -8,10 +8,6 @@ summary: >
     User defined functions, BLOBs, unordered sequences, 2GB+ files, preparation
     for decreasing schema compile time
 
-artifact-root: "https://archive.apache.org/dist/incubator/daffodil/2.5.0/"
-checksum-root: "https://archive.apache.org/dist/incubator/daffodil/2.5.0/"
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-2.5.0-incubating-src.zip"
 

--- a/site/_releases/2.6.0.md
+++ b/site/_releases/2.6.0.md
@@ -7,10 +7,6 @@ date: 2020-04-24
 summary: >
     Performance updates, API updates, Sonarqube analysis
 
-artifact-root: "https://archive.apache.org/dist/incubator/daffodil/2.6.0/"
-checksum-root: "https://archive.apache.org/dist/incubator/daffodil/2.6.0/"
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-2.6.0-incubating-src.zip"
 

--- a/site/_releases/2.7.0.md
+++ b/site/_releases/2.7.0.md
@@ -7,10 +7,6 @@ date: 2020-07-14
 summary: >
     Bug fixes, new features
 
-artifact-root: "https://archive.apache.org/dist/incubator/daffodil/2.7.0/"
-checksum-root: "https://archive.apache.org/dist/incubator/daffodil/2.7.0/"
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-2.7.0-incubating-src.zip"
 

--- a/site/_releases/3.0.0.md
+++ b/site/_releases/3.0.0.md
@@ -7,10 +7,6 @@ date: 2020-11-20
 summary: >
     SAX support, streaming, reduced memory usage, diagnostics, and bug fixes
 
-artifact-root: "https://archive.apache.org/dist/daffodil/3.0.0/"
-checksum-root: "https://archive.apache.org/dist/daffodil/3.0.0/"
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-3.0.0-incubating-src.zip"
 

--- a/site/_releases/3.1.0.md
+++ b/site/_releases/3.1.0.md
@@ -9,11 +9,6 @@ summary: >
     improved SAX conformance and performance, miscellaneous bug fixes and
     improvements
 
-artifact-root: "https://archive.apache.org/dist/daffodil/3.1.0/"
-checksum-root: "https://archive.apache.org/dist/daffodil/3.1.0/"
-
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-3.1.0-src.zip"
 

--- a/site/_releases/3.2.0.md
+++ b/site/_releases/3.2.0.md
@@ -7,11 +7,6 @@ date: 2021-12-06
 summary: >
     WARNING: This release has been superceded. Use Release 3.2.1 instead.
 
-artifact-root: "https://archive.apache.org/dist/daffodil/3.2.0/"
-checksum-root: "https://archive.apache.org/dist/daffodil/3.2.0/"
-
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-3.2.0-src.zip"
 

--- a/site/_releases/3.2.1.md
+++ b/site/_releases/3.2.1.md
@@ -11,11 +11,6 @@ summary: >
     Fixes unparse checksum and CRC capability (JIRA DAFFODIL-2609)
     Otherwise contains all the same functionality as Release 3.2.0 which it replaces.
 
-artifact-root: "https://archive.apache.org/dist/daffodil/3.2.1/"
-checksum-root: "https://archive.apache.org/dist/daffodil/3.2.1/"
-
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-3.2.1-src.zip"
 

--- a/site/_releases/3.3.0.md
+++ b/site/_releases/3.3.0.md
@@ -7,11 +7,6 @@ date: 2022-03-21
 summary: >
     Bug fixes and improvements
 
-artifact-root: "https://archive.apache.org/dist/daffodil/3.3.0/"
-checksum-root: "https://archive.apache.org/dist/daffodil/3.3.0/"
-
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-3.3.0-src.zip"
 

--- a/site/_releases/3.4.0.md
+++ b/site/_releases/3.4.0.md
@@ -8,11 +8,6 @@ summary: >
     EXI binary XML support, pluggable character sets, embedded XML, C code
     generator updates
 
-artifact-root: "https://www.apache.org/dyn/closer.lua/daffodil/3.4.0/"
-checksum-root: "https://downloads.apache.org/daffodil/3.4.0/"
-
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-3.4.0-src.zip"
 

--- a/site/_vscode/1.0.0.md
+++ b/site/_vscode/1.0.0.md
@@ -7,11 +7,6 @@ date: 2022-04-04
 summary: >
     Initial release
 
-artifact-root: "https://archive.apache.org/dist/daffodil/daffodil-vscode/1.0.0/"
-checksum-root: "https://archive.apache.org/dist/daffodil/daffodil-vscode/1.0.0/"
-
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-vscode-1.0.0-src.zip"
 

--- a/site/_vscode/1.1.0.md
+++ b/site/_vscode/1.1.0.md
@@ -7,11 +7,6 @@ date: 2022-08-22
 summary: >
     Initial omega-edit client & DFDL language
 
-artifact-root: "https://archive.apache.org/dist/daffodil/daffodil-vscode/1.1.0/"
-checksum-root: "https://archive.apache.org/dist/daffodil/daffodil-vscode/1.1.0/"
-
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-vscode-1.1.0-src.zip"
 

--- a/site/_vscode/1.2.0.md
+++ b/site/_vscode/1.2.0.md
@@ -8,11 +8,6 @@ summary: >
     Testing, omega-edit, intellisense, configuration and debugging
     improvements. Along with package upgrades and bug fixes.
 
-artifact-root: "https://www.apache.org/dyn/closer.lua/daffodil/daffodil-vscode/1.2.0/"
-checksum-root: "https://downloads.apache.org/daffodil/daffodil-vscode/1.2.0/"
-
-key-file: "https://downloads.apache.org/daffodil/KEYS"
-
 source-dist:
     - "apache-daffodil-vscode-1.2.0-src.zip"
 


### PR DESCRIPTION
The closer.lua page does not provide any information we don't already provide. The mirrors that it used to list have been replaced by a CDN, and we provide a message and link describing how to verify downloads on our download page. This has also been known to cause issues when users try to wget/curl a download link, since they just download an HTML page instead of the actual intended artifact, causing confusing about failed installations or invalid gpg signatures or checksums.

To avoid this issues, for apache release artifcts using closer.lua, this now appends ?action=download to the end of the URL so the download links skip the normal closer.lua page and instead download straight from the CDN.

Additionally, closer.lua is aware of archived artifacts, so we can use the same URL for archived and non-archived URLs. The downloads.apache.org URL is aware of archived .sha512 and .asc release artifacts, so these too can use the same URL for all releases. By using these URLs, we no longer need to update previous release pages when they are archived. We just need to delete old releases from dist.apache.org and the links will automatically redirect to the archives, removing one manual step from the release process.