### PR TITLE
Update the CSV example for flattend project layou

### DIFF
--- a/site/examples.md
+++ b/site/examples.md
@@ -30,7 +30,7 @@ Below are two examples of how Daffodil parses Comma-Separated Values (CSV) and P
 This DFDL schema is found at the DFDLSchemas GitHub [CSV repository](https://github.com/DFDLSchemas/CSV). 
 
 ```bash
-$ daffodil parse --schema CSV/src/main/resources/com/tresys/csv/xsd/csv.dfdl.xsd CSV/src/test/resources/com/tresys/csv/data/simpleCSV.csv
+$ daffodil parse --schema CSV/src/csv.dfdl.xsd CSV/test/simpleCSV.csv
 ```
 The above command uses the csv.dfdl.xsd schema to parse the simpleCSV.csv input data. The simpleCSV.csv contains the following data:
 


### PR DESCRIPTION
The CVS repo has been updated to use a flattened DFDL schema project layout. This updates the example CSV daffodil command to assume that layout so users are less likely to run into issues running the examples.