### PR TITLE
Fix broken Intellisense link for VSCode 1.2.0 release page.

### DIFF
--- a/site/_vscode/1.2.0.md
+++ b/site/_vscode/1.2.0.md
@@ -22,7 +22,7 @@ This release contains new features and fixes
 * Use Apache Daffodil v3.4.0.
 * Add debug option that uses configuration of last debug.
 * Update version of node and Scala dependencies.
-* Create Wiki page for [Intellisense Documentation](https://github.com/apache/daffodil-vscode/wiki/Using-DFDL-Intelli-sense).
+* Create Wiki page for [Intellisense Documentation](https://github.com/apache/daffodil-vscode/wiki/Apache-Daffodil%E2%84%A2-Extension-for-Visual-Studio-Code#dfdl-schema-authoring-using-code-completion).
 * omega-edit updates:
     * Implement search.
     * Implement search and replace.


### PR DESCRIPTION
Closes https://github.com/apache/daffodil-vscode/issues/365