### PR TITLE
Support release candidate download links

### DIFF
--- a/site/_includes/download-list.html
+++ b/site/_includes/download-list.html
@@ -3,15 +3,27 @@
 {% assign project = include.project %}
 {% assign type = include.type %}
 {% assign version = include.version %}
+{% assign release = include.release %}
 
 {% for file in artifacts %}
   {% if apache %}
     {% if file contains "incubating" %}
       {% assign project = "incubator/" | append: project %}
     {% endif %}
-    {% capture file-path %}{{project}}/{{version}}/{{type}}/{{file}}{% endcapture %}
-    {% capture artifact-url %}https://www.apache.org/dyn/closer.lua/download/{{file-path}}{% endcapture %}
-    {% capture checksum-url %}https://downloads.apache.org/{{file-path}}{% endcapture %}
+
+    {% if release == "final" %}
+        {% capture relver %}{{version}}{% endcapture %}
+        {% capture artifact-root %}https://www.apache.org/dyn/closer.lua/download{% endcapture %}
+        {% capture checksum-root %}https://downloads.apache.org{% endcapture %}
+    {% else %}
+        {% capture relver %}{{version}}-{{release}}{% endcapture %}
+        {% capture artifact-root %}https://dist.apache.org/repos/dist/dev{% endcapture %}
+        {% capture checksum-root %}https://dist.apache.org/repos/dist/dev{% endcapture %}
+    {% endif %}
+
+    {% capture file-path %}{{project}}/{{relver}}/{{type}}/{{file}}{% endcapture %}
+    {% capture artifact-url %}{{artifact-root}}/{{file-path}}{% endcapture %}
+    {% capture checksum-url %}{{checksum-root}}/{{file-path}}{% endcapture %}
   {% else %}
     {% capture artifact-url %}https://opensource.ncsa.illinois.edu/projects/artifacts.php?key=DFDL&version={{version}}&filename={{file}}{% endcapture %}
   {% endif %}

--- a/site/_includes/themes/apache/_navigation.html
+++ b/site/_includes/themes/apache/_navigation.html
@@ -55,7 +55,7 @@
     <h1>Apache Daffodil</h1>
     <p>Open-source implementation of the Data Format Description Language to convert between fixed format data and XML, JSON, and other data structures.</p>
 
-    {% assign latest = site.releases  | where: 'released', 'true' | sort: 'date' | last %}
+    {% assign latest = site.releases  | where: 'release', 'final' | sort: 'date' | last %}
     <a href="{{ latest.url }}" class="btn btn-primary btn-lg bigFingerButton" role="button">
       Get Daffodil {{ latest.title }}{% unless latest.apache %}, a Pre-Apache Release{% endunless %}!
     </a></p>

--- a/site/_layouts/release.html
+++ b/site/_layouts/release.html
@@ -3,13 +3,13 @@ layout: default
 permalink: /release/release-notes-:title
 ---
 
-{% unless page.released %}
+{% if page.release != "final" %}
   <div class="alert alert-warning">
     Apache Daffodil {{ page.title }} has not yet been released! The artifacts
     and release notes below are drafts for a proposed release of Apache
     Daffodil which has not yet occurred.
   </div>
-{% endunless %}
+{% endif %}
 
 {% unless page.apache %}
   <div class="alert alert-warning">
@@ -42,6 +42,7 @@ permalink: /release/release-notes-:title
              apache=page.apache
              artifacts=page.source-dist
              project="daffodil"
+             release=page.release
              type="src"
              version=page.title
           %}
@@ -55,6 +56,7 @@ permalink: /release/release-notes-:title
              apache=page.apache
              artifacts=page.binary-dist
              project="daffodil"
+             release=page.release
              type="bin"
              version=page.title
           %}

--- a/site/_layouts/vscode.html
+++ b/site/_layouts/vscode.html
@@ -3,13 +3,13 @@ layout: default
 permalink: /vscode/release-notes-:title
 ---
 
-{% unless page.released %}
+{% if page.release != "final" %}
   <div class="alert alert-warning">
     Apache Daffodil VS Code Extension {{ page.title }} has not yet been released! The artifact
     and release notes below are drafts for a proposed release of Apache
     Daffodil VS Code Extension which has not yet occurred.
   </div>
-{% endunless %}
+{% endif %}
 
 <div class="row">
   {% capture docx_path %}/docs/vscode/{{page.title}}/Apache-Daffodil-Extension-for-Visual-Studio-Code-{{page.title}}.docx{% endcapture %}
@@ -38,6 +38,7 @@ permalink: /vscode/release-notes-:title
              apache=page.apache
              artifacts=page.source-dist
              project="daffodil/daffodil-vscode"
+             release=page.release
              type="src"
              version=page.title
           %}
@@ -51,6 +52,7 @@ permalink: /vscode/release-notes-:title
              apache=page.apache
              artifacts=page.binary-dist
              project="daffodil/daffodil-vscode"
+             release=page.release
              type="bin"
              version=page.title
           %}

--- a/site/_releases/1.0.0.md
+++ b/site/_releases/1.0.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: false
 title: 1.0.0
 date: 2015-03-02

--- a/site/_releases/1.1.0.md
+++ b/site/_releases/1.1.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: false
 title: 1.1.0
 date: 2015-06-04

--- a/site/_releases/2.0.0.md
+++ b/site/_releases/2.0.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: false
 title: 2.0.0
 date: 2017-09-05

--- a/site/_releases/2.1.0.md
+++ b/site/_releases/2.1.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 2.1.0
 date: 2018-05-14

--- a/site/_releases/2.2.0.md
+++ b/site/_releases/2.2.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 2.2.0
 date: 2018-09-04

--- a/site/_releases/2.3.0.md
+++ b/site/_releases/2.3.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 2.3.0
 date: 2019-02-26

--- a/site/_releases/2.4.0.md
+++ b/site/_releases/2.4.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 2.4.0
 date: 2019-07-12

--- a/site/_releases/2.5.0.md
+++ b/site/_releases/2.5.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 2.5.0
 date: 2020-01-12

--- a/site/_releases/2.6.0.md
+++ b/site/_releases/2.6.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 2.6.0
 date: 2020-04-24

--- a/site/_releases/2.7.0.md
+++ b/site/_releases/2.7.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 2.7.0
 date: 2020-07-14

--- a/site/_releases/3.0.0.md
+++ b/site/_releases/3.0.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 3.0.0
 date: 2020-11-20

--- a/site/_releases/3.1.0.md
+++ b/site/_releases/3.1.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 3.1.0
 date: 2021-05-18

--- a/site/_releases/3.2.0.md
+++ b/site/_releases/3.2.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 3.2.0
 date: 2021-12-06

--- a/site/_releases/3.2.1.md
+++ b/site/_releases/3.2.1.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 3.2.1
 date: 2021-12-22

--- a/site/_releases/3.3.0.md
+++ b/site/_releases/3.3.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 3.3.0
 date: 2022-03-21

--- a/site/_releases/3.4.0.md
+++ b/site/_releases/3.4.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 3.4.0
 date: 2022-11-08

--- a/site/_vscode/1.0.0.md
+++ b/site/_vscode/1.0.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 1.0.0
 date: 2022-04-04

--- a/site/_vscode/1.1.0.md
+++ b/site/_vscode/1.1.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 1.1.0
 date: 2022-08-22

--- a/site/_vscode/1.2.0.md
+++ b/site/_vscode/1.2.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: true
+release: final
 apache: true
 title: 1.2.0
 date: 2022-12-06

--- a/site/_vscode/1.3.0.md
+++ b/site/_vscode/1.3.0.md
@@ -1,6 +1,6 @@
 ---
 
-released: false
+release: rc1
 apache: true
 title: 1.3.0
 date: 2023-4-27

--- a/site/releases.md
+++ b/site/releases.md
@@ -26,7 +26,7 @@ All recent Daffodil releases are listed here, along with several historical rele
 
 ### Apache Releases
 
-{% assign releases = site.releases  | where: 'released', 'true' | where: 'apache', 'true' | sort: 'date' %}
+{% assign releases = site.releases  | where: 'release', 'final' | where: 'apache', 'true' | sort: 'date' %}
 {% if releases.size > 0 %}
 <table class="table">
     <tr>
@@ -58,7 +58,7 @@ No official Apache releases have been made yet. <a href="/community">Get involve
     and are licensed under the <a href="https://opensource.org/licenses/NCSA">NCSA license</a>.
 </div>
 
-{% assign releases = site.releases  | where: 'released', 'true' | where: 'apache', 'false' | sort: 'date' %}
+{% assign releases = site.releases  | where: 'release', 'final' | where: 'apache', 'false' | sort: 'date' %}
 <table class="table">
     <tr>
         <th class="col-md-1">Version</th>

--- a/site/vscode.md
+++ b/site/vscode.md
@@ -28,7 +28,7 @@ The Daffodil VS Code Extension is a custom extension developed by Apache for all
 
 All recent Daffodil VS Code Extension releases are listed here. Each release below is listed by the version and date on which it was released. Clicking on the version number will take you to the release notes and downloads for that release.
 
-{% assign releases = site.vscode  | where: 'released', 'true' | where: 'apache', 'true' | sort: 'date' %}
+{% assign releases = site.vscode  | where: 'release', 'final' | where: 'apache', 'true' | sort: 'date' %}
 {% if releases.size > 0 %}
 <table class="table">
     <tr>


### PR DESCRIPTION
The recent changes to how we create download links was broken for release candidates. To support this, this removes the "released" boolean property and replaces it with a "release" property. This new property should be set to "final" for released artifacts or set to the release candidate name (e.g. "rc1") for release candidates. The download links are modified to point to dist.apache.org and to include the "-rcX" in the version name for release candidates.