### PR TITLE
Fix vscode release 1.3.1

### DIFF
--- a/site/_vscode/1.3.1.md
+++ b/site/_vscode/1.3.1.md
@@ -1,6 +1,6 @@
 ---
 
-release: true
+release: final
 apache: true
 title: 1.3.1
 date: 2023-09-12


### PR DESCRIPTION
@stevedlawrence My apologies, I didn't realize for each RC the `release` attribute was supposed to match that RC number. Will make sure to do this in the future.