### PR TITLE
Use asf.yml to publish the website

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -28,3 +28,5 @@ notifications:
     commits:      commits@daffodil.apache.org
     issues:       commits@daffodil.apache.org
     pullrequests: commits@daffodil.apache.org
+publish:
+  whoami: asf-site


### PR DESCRIPTION
The latest page was not published, maybe explicitly specifying asf-site in asf.yml will fix it.