### PR TITLE
Fix typo in 1.4.0 release page

### DIFF
--- a/site/_vscode/1.4.0.md
+++ b/site/_vscode/1.4.0.md
@@ -5,7 +5,7 @@ apache: true
 title: 1.4.0
 date: 2024-11-13
 summary: >
-    Adds debugger, data editor, TDNL and intellisense improvements
+    Adds debugger, data editor, TDML and intellisense improvements
     along with package upgrades and bug fixes.
 
 source-dist:


### PR DESCRIPTION
For some reason the other didn't fully merge properly