### PR TITLE
Update 3.10.0 release notes to emphasize some changed behavior

### DIFF
--- a/site/_releases/3.10.0.md
+++ b/site/_releases/3.10.0.md
@@ -68,7 +68,6 @@ compilation time dropping from more than 2 minutes to under 20 seconds.
 * {% jira 2962 %} Complex nillable leads to Expression Evaluation Error: Element does not have a value.
 * {% jira 2965 %} Improve Schema Compiler performance
 * {% jira 533 %} TDML Runner: More user-friendly error if expected infoset provided is empty
-* {% jira 1042 %} Date and Time Strict Parsing is not very strict
 * {% jira 2362 %} JSON output should not quote all values unnecessarily
 * {% jira 2773 %} Expression .[intexpr] should create warning
 * {% jira 2797 %} Make Runner final
@@ -104,10 +103,17 @@ compilation time dropping from more than 2 minutes to under 20 seconds.
 * {% jira 2896 %} validationMode=full enables Daffodils limited validation
 
   Full Validation no longer performs limited validation in addition to Xerces validation. It now only performs Xerces validation.
+  This has resulted in some changes to error messages that are reported during validation, which may require updates to any tests
+  that are expecting validation error messages that are specific to the limited validation process.
 
 * {% jira 2773 %} Expression .[intexpr] should create warning
 
   Removed the text "subset" from the "Indexing is only allowed on arrays" Schema Definition Error message.
+
+* {% jira 1042 %} Date and Time Strict Parsing is not very strict
+
+  Daffodil had been parsing xs:date/time leniently regardless of what dfdl:calendarCheckPolicy had been set to. This change may
+  require some changes to schemas that were reliant on this faulty behavior and may need to set dfdl:calendarCheckPolicy="lax".
 
 ### Dependency Changes
 


### PR DESCRIPTION
Daffodil 3.10.0 fixed some bugs that may require small updates to some schemas that had been relying on incorrect behavior. This commit emphasizes these changes in the release notes.