### PR TITLE
Add link to 3.11.0 transition documentation

### DIFF
--- a/site/_releases/3.11.0.md
+++ b/site/_releases/3.11.0.md
@@ -35,6 +35,8 @@ fixes and process improvements that are included with this release.
   - For those using the Daffodil API from Java, the transition should be
     seamless
 
+  See [Daffodil 3.11.0 and Scala 2.13 Transition](https://cwiki.apache.org/confluence/display/DAFFODIL/Daffodil+3.11.0+and+Scala+2.13+Transition) for more details.
+
 * {% jira 2152 %} Add support for Scala 2.13
 * {% jira 2987 %} Drop Scala 2.12
 

--- a/site/_sbt/1.4.0.md
+++ b/site/_sbt/1.4.0.md
@@ -27,10 +27,12 @@ See the [GitHub page](https://github.com/apache/daffodil-sbt) for details to ena
   that require different major versions of Scala simultaneously. For example:
   `daffodilPackageBinVersions := Seq("3.10.0", "3.11.0")`
   is not supported as Daffodil 3.10.0 requires Scala 2.12 and Daffodil 3.11.0
-  requires Scala 2.13. Building them separately with the appropriate changes to
-  `daffodilVersion` and `daffodilPackageBinVersions` is supported, assuming all
-  Scala based test/plugin/layer code is cross compatible between Scala 2.12 and
-  2.13
+  requires Scala 2.13. Building them separately or in different SBT subprojects
+  with the appropriate changes to `daffodilVersion` and
+  `daffodilPackageBinVersions` is supported, assuming all Scala based
+  test/plugin/layer code is cross compatible between Scala 2.12 and 2.13.
+  See [Daffodil 3.11.0 and Scala 2.13 Transition](https://cwiki.apache.org/confluence/display/DAFFODIL/Daffodil+3.11.0+and+Scala+2.13+Transition)
+  for more details.
 
 #### Closed Issues
 


### PR DESCRIPTION
Added the link to both the release notes for Daffodil 3.11.0 and Daffodil SBT Plugin 1.4.0