### PR TITLE
Add documentation update for javadoc for Scala 3

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -93,9 +93,14 @@ jobs:
           rm -rf $DOCS_DIR
           rm -rf $TUTORIALS_DIR
 
+          # generate javadoc using scalaunidoc
           sbt unidoc
           mkdir -p $DOCS_DIR/{javadoc,scaladoc}/
-          cp -R target/javaunidoc/* $DOCS_DIR/javadoc/
+          cp -R target/scala-*/unidoc/* $DOCS_DIR/javadoc/
+          
+          # generate scaladoc using scalaunidoc
+          touch daffodil-core/src/main/java/dummy.scala
+          sbt unidoc
           cp -R target/scala-*/unidoc/* $DOCS_DIR/scaladoc/
 
           mkdir -p $TUTORIALS_DIR


### PR DESCRIPTION
- our api is now in java. An all-java codebase allows scalaunidoc to generate javadoc (which is necessary since javaunidoc requires a plugin that doesn't support scala 3), to generate scaladoc, we have a dummy scala file which then causes scalaunidoc to generate scaladoc
- requires merging of https://github.com/apache/daffodil/pull/1479 first

DAFFODIL-2975