### PR TITLE
Remove the Scala API from the website

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -94,9 +94,8 @@ jobs:
           rm -rf $TUTORIALS_DIR
 
           sbt unidoc
-          mkdir -p $DOCS_DIR/{javadoc,scaladoc}/
-          cp -R target/javaunidoc/* $DOCS_DIR/javadoc/
-          cp -R target/scala-*/unidoc/* $DOCS_DIR/scaladoc/
+          mkdir -p $DOCS_DIR/javadoc/
+          cp -R target/scala-*/unidoc/* $DOCS_DIR/javadoc/
 
           mkdir -p $TUTORIALS_DIR
           cp -R tutorials/src/main/resources/* $TUTORIALS_DIR/

--- a/site/_includes/themes/apache/_navigation.html
+++ b/site/_includes/themes/apache/_navigation.html
@@ -16,8 +16,7 @@
               <ul class="dropdown-menu dropdown-left">
                 <li><a href="/getting-started/">Getting Started</a></li>
                 <li><a href="/examples/">Examples</a></li>
-                <li><a href="/docs/latest/javadoc/">Java API</a></li>
-                <li><a href="/docs/latest/scaladoc/">Scala API</a></li>
+                <li><a href="/docs/latest/javadoc/">API</a></li>
                 <li><a href="/docs/dfdl/">DFDL Specification</a></li>
                 <li><a href="/unsupported/">Unsupported Features</a></li>
                 <li><a href="/faq/">Frequently Asked Questions</a></li>

--- a/site/_layouts/release.html
+++ b/site/_layouts/release.html
@@ -22,7 +22,8 @@ permalink: /release/release-notes-:title
 <div class="row">
   <div class="col-md-3 text-right" style="float: right; z-index: 3;">
     <h3>Documentation</h3>
-    <a href="/docs/{{ page.title }}/javadoc/">Javadoc</a> | <a href="/docs/{{ page.title }}/scaladoc/">Scaladoc</a>
+    {% assign major_version = page.title | split: '.' | first | plus: 0 %}
+    <a href="/docs/{{ page.title }}/javadoc/">Javadoc</a>{% if major_version < 4 %} | <a href="/docs/{{ page.title }}/scaladoc/">Scaladoc</a>{% endif %}
   </div>
 
   <div class="col-md-12">

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -30,9 +30,9 @@ Daffodil is a library, requiring Java 8, used to convert between fixed format da
 
    : Linux and Windows command line tool with capabilities include parsing, unaparsing, an interactive debugger, and more. Available via download in binary [releases](/releases).
 
-[Java API](/docs/latest/javadoc) or [Scala API](/docs/latest/scaladoc)
+[API](/docs/latest/javadoc)
 
-   : Examples for using the Java API are available on the [OpenDFDL examples](https://github.com/OpenDFDL/examples.git) repository. Individual [releases](/releases) describe how to include a dependency to Daffodil via Maven and SBT.
+   : Examples for using the API in both Java and Scala are available on the [OpenDFDL examples](https://github.com/OpenDFDL/examples.git) repository. Individual [releases](/releases) describe how to include a dependency to Daffodil via Maven and SBT.
 
 [Apache NiFi Processors](https://github.com/TresysTechnology/nifi-daffodil)
 


### PR DESCRIPTION
With the move to Scala 3 and our API written entirely in Java, there is no way to generate scaladoc-style documentation. These changes are made:

- The update-docs workflow run during releases no longer creates a scaladoc directory. Note that target/scala-*/unidoc now contains javadoc because all our our API files are .java.
- Remove "Java API" and "Scala API" from the navigation bar, replacing them with just an "API" link to the javadocs.
- For release pages 4.0.0 and newer, do not output the "Scaladoc" link
- Remove references to "Java API" and "Scala API" in the getting started page, replacing it with "API"