### PR TITLE
Use Java 17 when building Daffodil docs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         java_distribution: [ temurin ]
-        java_version: [ 8 ]
+        java_version: [ 17 ]
 
     runs-on: ubuntu-22.04
     env:


### PR DESCRIPTION
Building Daffodil, which is used to create generate docs, requires Java 17